### PR TITLE
BJS2-33380 Конфигурация логирования в payment_service

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,2 @@
 server:
   port: 9080
-
-logging:
-  level:
-    root: info

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,10 +1,33 @@
 <configuration>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>
+                %blue(%d{yyyy-MM-dd HH:mm:ss.SSS}) %cyan([%thread]) %highlight(%-5level) %magenta(%logger{36}) %magenta(-) %highlight(%msg) %n
+            </pattern>
         </encoder>
     </appender>
-    <root level="INFO">
-        <appender-ref ref="CONSOLE" />
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <rollingPolicy
+                class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./logs/log-%d{yyyy-MM-dd}_%i.log.gz</fileNamePattern>
+            <maxHistory>10</maxHistory>
+            <maxFileSize>100MB</maxFileSize>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>
+                %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="CONSOLE"/>
     </root>
 </configuration>


### PR DESCRIPTION
Изменил аппендер "CONSOLE". Имя и класс оставлены без изменений.
Повесил фильтр для логов уровня INFO и выше.
Паттерн в encoder-е:
- `%d{yyyy-MM-dd HH:mm:ss.SSS}`: Выводит текущую дату и время в заданном формате, покрашен в blue.
- `%thread`: Выводит имя потока, покрашен в cyan.
- `%level`: Выводит уровень лога, использую %highlight(красит INFO в blue, WARN в red, ERROR в boldRed).
- `%logger{36}`: Выводит имя логгера, усеченное до 36 символов, покрашен в magenta.
- `-`: Просто выводит символ "-", покрашен в magenta.
- `%msg`: Выводит сообщение лога, использую %highlight(красит INFO в blue, WARN в red, ERROR в boldRed).
- `%n`: Символ новой строки.

Добавлен аппендер "FILE" для вывода логов в файл-журнал в директории проекта(прим. user_service/logs/).
Использую имя "FILE" и классы RollingFileAppender и SizeAndTimeBasedRollingPolicy.
Свойство конфигурации fileNamePattern добавляет логи в файл-журнал с определенным именем и в определенной директории. При необходимости создает новый.
- `./logs`: Имя определенной директории в корне проекта.
- `log-`: Статический префикс для имени файла-журнала логов.
- `%d{yyy-MM-dd}`: Текущая дата в заданном формате.
- `_%i`:  Индекс файла-журнала логов, который увеличивается для каждого нового журнала в текущей дате.
- `.log.gz`: сжатие с помощью gzip.

Свойство конфигурации maxHistory лимитирует кол-во дней хранения журнала.
Свойство конфигурации maxFileSize лимитирует размер одного файла-журнала.
Свойство конфигурации totalSizeCap лимитирует размер выделяемого под все журналы.
Паттерн в encoder-е, повторяет паттерн из аппендера "CONSOLE", но без покраски.

Установлен уровень логирования для КОРНЕВОЙ среды на DEBUG.
Свойство конфигурации appender-ref это ссылка на аппендер.