### PR TITLE
BJS2-52470

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:2.14.2")
     implementation("org.slf4j:slf4j-api:2.0.5")
     implementation("ch.qos.logback:logback-classic:1.4.6")
+    implementation("org.codehaus.janino:janino:3.1.10")
     implementation("org.projectlombok:lombok:1.18.26")
     annotationProcessor("org.projectlombok:lombok:1.18.26")
     implementation("org.mapstruct:mapstruct:1.5.3.Final")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:2.14.2")
     implementation("org.slf4j:slf4j-api:2.0.5")
     implementation("ch.qos.logback:logback-classic:1.4.6")
-    implementation("org.codehaus.janino:janino:3.1.10")
     implementation("org.projectlombok:lombok:1.18.26")
     annotationProcessor("org.projectlombok:lombok:1.18.26")
     implementation("org.mapstruct:mapstruct:1.5.3.Final")

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,6 @@
 server:
   port: 9080
 
-logging:
-  level:
-    root: info
+spring:
+  profiles:
+    active: local

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,10 +1,95 @@
 <configuration>
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-    <root level="INFO">
-        <appender-ref ref="CONSOLE" />
-    </root>
+    <springProfile name="local">
+        <root level="DEBUG">
+            <appender-ref ref="CONSOLE_ERROR"/>
+            <appender-ref ref="CONSOLE_WARN"/>
+            <appender-ref ref="CONSOLE_INFO"/>
+            <appender-ref ref="CONSOLE_DEBUG"/>
+            <appender-ref ref="FILE_LOCAL"/>
+        </root>
+
+        <appender name="FILE_LOCAL" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>logs/app.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>logs/app.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>10MB</maxFileSize>
+                <maxHistory>5</maxHistory>
+                <totalSizeCap>70MB</totalSizeCap>
+            </rollingPolicy>
+            <encoder>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %level %logger{36} - %msg%n</pattern>
+                <charset>UTF-8</charset>
+            </encoder>
+        </appender>
+
+        <appender name="CONSOLE_ERROR" class="ch.qos.logback.core.ConsoleAppender">
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>ERROR</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
+            <encoder>
+                <pattern>%red(%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %level %logger{36} - %msg%n)</pattern>
+                <charset>UTF-8</charset>
+            </encoder>
+        </appender>
+
+        <appender name="CONSOLE_WARN" class="ch.qos.logback.core.ConsoleAppender">
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>WARN</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
+            <encoder>
+                <pattern>%yellow(%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %level %logger{36} - %msg%n)</pattern>
+                <charset>UTF-8</charset>
+            </encoder>
+        </appender>
+
+        <appender name="CONSOLE_INFO" class="ch.qos.logback.core.ConsoleAppender">
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>INFO</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
+            <encoder>
+                <pattern>%green(%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %level %logger{36} - %msg%n)</pattern>
+                <charset>UTF-8</charset>
+            </encoder>
+        </appender>
+
+        <appender name="CONSOLE_DEBUG" class="ch.qos.logback.core.ConsoleAppender">
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>DEBUG</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
+            <encoder>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %level %logger{36} - %msg%n</pattern>
+                <charset>UTF-8</charset>
+            </encoder>
+        </appender>
+    </springProfile>
+
+    <springProfile name="!local">
+        <if condition='!property("SPRING_PROFILES_ACTIVE").contains("local")'>
+            <root level="INFO">
+                <appender-ref ref="FILE"/>
+            </root>
+        </if>
+
+        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>logs/app.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>logs/app.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>100MB</maxFileSize>
+                <maxHistory>5</maxHistory>
+                <totalSizeCap>700MB</totalSizeCap>
+            </rollingPolicy>
+            <encoder>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %level %logger{36} - %msg%n</pattern>
+                <charset>UTF-8</charset>
+            </encoder>
+        </appender>
+    </springProfile>
 </configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,6 +1,6 @@
 <configuration>
     <springProfile name="local">
-        <root level="DEBUG">
+        <root level="INFO">
             <appender-ref ref="CONSOLE_ERROR"/>
             <appender-ref ref="CONSOLE_WARN"/>
             <appender-ref ref="CONSOLE_INFO"/>
@@ -14,7 +14,7 @@
                 <fileNamePattern>logs/app.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
                 <maxFileSize>10MB</maxFileSize>
                 <maxHistory>5</maxHistory>
-                <totalSizeCap>70MB</totalSizeCap>
+                <totalSizeCap>100MB</totalSizeCap>
             </rollingPolicy>
             <encoder>
                 <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %level %logger{36} - %msg%n</pattern>
@@ -53,7 +53,7 @@
                 <onMismatch>DENY</onMismatch>
             </filter>
             <encoder>
-                <pattern>%green(%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %level %logger{36} - %msg%n)</pattern>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %level %logger{36} - %msg%n</pattern>
                 <charset>UTF-8</charset>
             </encoder>
         </appender>
@@ -65,18 +65,23 @@
                 <onMismatch>DENY</onMismatch>
             </filter>
             <encoder>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %level %logger{36} - %msg%n</pattern>
+                <pattern>%green(%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %level %logger{36} - %msg%n)</pattern>
                 <charset>UTF-8</charset>
             </encoder>
         </appender>
     </springProfile>
 
     <springProfile name="!local">
-        <if condition='!property("SPRING_PROFILES_ACTIVE").contains("local")'>
             <root level="INFO">
+                <appender-ref ref="CONSOLE"/>
                 <appender-ref ref="FILE"/>
             </root>
-        </if>
+
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            </encoder>
+        </appender>
 
         <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
             <file>logs/app.log</file>


### PR DESCRIPTION
BJS2-52470 
logback
Предлагаю утвердить на этом сервисе, если все ок - раскатать на все остальные.
Параметры логгирования настраиваются через профиль спринга. Если профиль = local, тогда установлен уровень DEBUG. Логи выводятся на консоль ( в разных цветах) + в файл. Файлы хранят историю за последние 5 дней, максимальный размер одного файла 10 МБ, общий размер логов не более 70 МБ.

Если спринг профиль != local, тогда установлен уровень INFO. Логи пишутся ТОЛЬКО в файл, на консоли ничего не будет. В таком случае история хранится за последние 5 дней, максимальный размер одного файла 100 МБ, общий размер логов не более 700 МБ.
![Screenshot_11](https://github.com/user-attachments/assets/88809532-0a9f-4051-ac9a-3b8c9b7b3535)
